### PR TITLE
Update vte.SlackBuild

### DIFF
--- a/slackbuilds/vte/vte.SlackBuild
+++ b/slackbuilds/vte/vte.SlackBuild
@@ -62,7 +62,7 @@ else
   LIBDIRSUFFIX=""
 fi
 
-TMP=${TMP:-/tmp}
+TMP=${TMP:-/tmp/SBo}
 PKG=$TMP/package-${PKGNAM}
 
 rm -rf $PKG


### PR DESCRIPTION
added SBo to the $TMP path.
If doing a full clean install using sbopkg, it stops on vte and does not proceed until you manually install the pkg.