### PR TITLE
Update xdg-desktop-portal-gnome.SlackBuild

### DIFF
--- a/slackbuilds/xdg-desktop-portal-gnome/xdg-desktop-portal-gnome.SlackBuild
+++ b/slackbuilds/xdg-desktop-portal-gnome/xdg-desktop-portal-gnome.SlackBuild
@@ -27,7 +27,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=xdg-desktop-portal-gnome	
 VERSION=${VERSION:-42.1}
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-2}
 TAG=${TAG:-_SBo}	
 PKGTYPE=${PKGTYPE:-tgz}
 
@@ -96,7 +96,7 @@ cd build
     --prefix=/usr \
     --sysconfdir=/etc \
     --datadir=/usr/share/applications \
-    -Dsystemduserunitdir=no \
+    -Dsystemduserunitdir="/usr/lib/systemd/user" \
     -Ddbus_service_dir="/usr/share/dbus-1/system.d" \
     -Dstrip=true
   "${NINJA:=ninja}"


### PR DESCRIPTION
Previously, with "-Dsystemduserunitdir=no" set, the package would install a .service file in" /usr/no" as the expected answer here is a location, not a boolean value. Also updated the build #, as I think that change warrants a re-build.