### PR TITLE
Update gnome-terminal.SlackBuild

### DIFF
--- a/slackbuilds/gnome-terminal/gnome-terminal.SlackBuild
+++ b/slackbuilds/gnome-terminal/gnome-terminal.SlackBuild
@@ -26,7 +26,7 @@ cd $(dirname $0) ; CWD=$(pwd)
 
 PRGNAM=gnome-terminal
 VERSION=${VERSION:-3.44.1}
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-2}
 TAG=${TAG:-_SBo}
 PKGTYPE=${PKGTYPE:-tgz}
 
@@ -101,6 +101,14 @@ cd ..
 
 # Don't ship .la files:
 rm -f $PKG/{,usr/}lib${LIBDIRSUFFIX}/*.la
+
+# build does not honor the --mandir setting, so lets move it ourselves
+mkdir -p $PKG/usr/man/man1
+mv $PKG/usr/share/man/man1/* $PKG/usr/man/man1
+rm -R $PKG/usr/share/man
+    
+find $PKG/usr/man -type f -exec gzip -9 {} \;
+for i in $( find $PKG/usr/man -type l ) ; do ln -s $( readlink $i ).gz $i.gz ; rm $i ; done
 
 # Strip binaries and libraries - this can be done with 'make install-strip'
 # in many source trees, and that's usually acceptable if so, but if not,


### PR DESCRIPTION
Installation ignores the --mandir flag and places the manpage in /usr/share/man, added a fix to move and gzip it correctly.